### PR TITLE
Fix request syntax and module init

### DIFF
--- a/hybrid_search/__init__.py
+++ b/hybrid_search/__init__.py
@@ -1,0 +1,1 @@
+from .hybrid_search import HybridSearch

--- a/proxy/hybrid_search.py
+++ b/proxy/hybrid_search.py
@@ -29,7 +29,7 @@ class HybridSearch:
     def get_embedding(self, text):
         """Get embedding vector for text using Ollama"""
         try:
-            response = requests.get(timeout=10, 
+            response = requests.get(
                 f"{self.ollama_url}/api/embed",
                 json={"model": "nomic-embed-text", "prompt": text},
                 timeout=60
@@ -123,7 +123,7 @@ class HybridSearch:
         api_url = "http://open-webui:8080/api/v1/knowledge/query"
         
         try:
-            response = requests.get(timeout=10, 
+            response = requests.get(
                 api_url,
                 json={
                     "query": query_text,


### PR DESCRIPTION
## Summary
- fix bad argument ordering in `proxy/hybrid_search.py`
- make `hybrid_search` a package so `HybridSearch` can be imported directly

## Testing
- `python -m compileall -q hybrid_search proxy document_processor.py neo4j_integration`

## Summary by Sourcery

Fix improper argument ordering in HTTP requests and enable direct import of HybridSearch by converting hybrid_search into a package

Bug Fixes:
- Correct argument ordering for requests.get calls in proxy/hybrid_search.py to ensure timeouts are applied properly

Enhancements:
- Add __init__.py to hybrid_search to make it a package and allow direct import of HybridSearch