### PR TITLE
Fix start.sh quoting and improve proxy configuration

### DIFF
--- a/proxy/ollama_proxy.py
+++ b/proxy/ollama_proxy.py
@@ -1,9 +1,30 @@
 from flask import Flask, request, jsonify
+import os
 import requests
 from hybrid_search import HybridSearch
 
 app = Flask(__name__)
-hybrid_search = HybridSearch()
+
+# Connection details from environment variables
+NEO4J_URI = os.environ.get("NEO4J_URI", "bolt://neo4j:7687")
+NEO4J_USER = os.environ.get("NEO4J_USER", "neo4j")
+NEO4J_PASSWORD = os.environ.get("NEO4J_PASSWORD", "VerySecurePassword")
+MILVUS_HOST = os.environ.get("MILVUS_HOST", "milvus-standalone")
+MILVUS_PORT = os.environ.get("MILVUS_PORT", "19530")
+OLLAMA_API_BASE_URL = os.environ.get("OLLAMA_API_BASE_URL", "http://ollama:11434")
+
+try:
+    hybrid_search = HybridSearch(
+        neo4j_uri=NEO4J_URI,
+        neo4j_user=NEO4J_USER,
+        neo4j_password=NEO4J_PASSWORD,
+        milvus_host=MILVUS_HOST,
+        milvus_port=MILVUS_PORT,
+        ollama_url=OLLAMA_API_BASE_URL,
+    )
+except Exception as exc:
+    print(f"Failed to initialise HybridSearch: {exc}")
+    hybrid_search = None
 
 @app.route('/api/<path:path>', methods=['GET', 'POST', 'PUT', 'DELETE'])
 def proxy(path):
@@ -15,15 +36,23 @@ def proxy(path):
         return jsonify({"message": {"content": "This is a placeholder response since hybrid search is being fixed."}})
     
     # For all other requests, pass through to Ollama
-    url = f"http://ollama:11434/api/{path}"
+    url = f"{OLLAMA_API_BASE_URL}/api/{path}"
     print(f"Proxying request to: {url} (Method: {request.method})")
-    
-    # Forward the request
-    if request.method == 'GET':
-        resp = requests.get(url, params=request.args)
-    else:
-        resp = requests.post(url, json=request.json)
-    
+
+    headers = {k: v for k, v in request.headers if k.lower() != 'host'}
+    try:
+        resp = requests.request(
+            method=request.method,
+            url=url,
+            params=request.args,
+            json=request.get_json(silent=True),
+            headers=headers,
+            timeout=300,
+        )
+    except requests.RequestException as exc:
+        print(f"Request to Ollama failed: {exc}")
+        return jsonify({"error": "Failed to contact Ollama"}), 502
+
     print(f"Response from {url}: status {resp.status_code}")
     return resp.content, resp.status_code, resp.headers.items()
 

--- a/start.sh
+++ b/start.sh
@@ -209,9 +209,10 @@ setup_jarvis_model() {
     
     # Using local file instead of base64 for better compatibility
     if [ -f Modelfile ]; then
-        cat Modelfile | curl -X POST "http://localhost:11434/api/create" \
+        modelfile_contents=$(tr '\n' ' ' < Modelfile | sed 's/"/\\"/g')
+        curl -X POST "http://localhost:11434/api/create" \
             -H "Content-Type: application/json" \
-            -d '{"name": "jarvis", "modelfile": "'"$(cat Modelfile | sed 's/"/\\"/g' | tr '\n' ' ')"'"}'
+            -d "{\"name\": \"jarvis\", \"modelfile\": \"${modelfile_contents}\"}"
         
         echo -e "\n${GREEN}Jarvis model creation initiated. This may take some time to complete.${NC}"
     else


### PR DESCRIPTION
## Summary
- fix jarvis model creation command quoting in `start.sh`
- initialize `HybridSearch` with environment variables in proxy
- forward all headers and handle errors when proxying requests

## Testing
- `bash -n start.sh`
- `python -m py_compile ollama_proxy.py proxy/ollama_proxy.py`
- `pytest -q` *(fails: command not found)*

## Summary by Sourcery

Configure the proxy to use environment variables for backend services, enhance request forwarding with header preservation and error handling, and fix JSON quoting in start.sh for reliable model creation.

Bug Fixes:
- Fix JSON quoting in start.sh to correctly embed model file contents in the create request.

Enhancements:
- Initialize HybridSearch using configurable environment variables with sensible defaults and fallback on initialization errors.
- Replace hard-coded Ollama API URL with a configurable base URL and unify proxy logic via requests.request with a timeout.
- Forward all incoming headers (excluding Host) when proxying requests and return HTTP 502 on upstream failures.