### PR TITLE
Improve GPU usage defaults

### DIFF
--- a/Modelfile
+++ b/Modelfile
@@ -6,7 +6,7 @@ You are Jarvis, an advanced bilingual AI assistant fluent in both English and Du
 """
 PARAMETER num_ctx 131072
 PARAMETER num_gpu 2
-PARAMETER num_thread 12
+PARAMETER num_thread 24
 PARAMETER num_batch 512
 PARAMETER temperature 0.7
 PARAMETER top_k 40

--- a/Modelfile.optimized
+++ b/Modelfile.optimized
@@ -10,7 +10,7 @@ PARAMETER tensors.gpu 1
 PARAMETER tensor_split "[0.5, 0.5]"
 # Original parameters that are still relevant
 PARAMETER num_ctx 131072
-PARAMETER num_thread 12
+PARAMETER num_thread 24
 PARAMETER num_batch 512
 PARAMETER temperature 0.7
 PARAMETER top_k 40

--- a/README.md
+++ b/README.md
@@ -317,14 +317,24 @@ The LLM is configured in the `Modelfile`. You can modify this file to change LLM
     """
     PARAMETER num_ctx 131072
     PARAMETER num_gpu 2
-    PARAMETER num_thread 12
+    PARAMETER num_thread 24
     PARAMETER num_batch 512
     PARAMETER temperature 0.7
     PARAMETER top_k 40
     PARAMETER top_p 0.9
     PARAMETER repeat_penalty 1.1
-    
+
     TEMPLATE """{{ if .System }}<|start_header_id|>system<|end_header_id|> {{ .System }} <|eot_id|>{{ end }}{{ if .Prompt }}<|start_header_id|>user<|end_header_id|> {{ .Prompt }} <|eot_id|>{{ end }}<|start_header_id|>assistant<|end_header_id|> {{ .Response }} <|eot_id|>"""
+
+#### Optimizing for Dual V100 GPUs
+
+For systems with two NVIDIA V100 GPUs and high core-count CPUs, adjust the following settings for best performance:
+
+* `OLLAMA_NUM_THREADS=24` in `docker-compose.yml` to match the available CPU threads.
+* `WEBUI_WORKERS=12` in `docker-compose.yml` for improved concurrency in the web interface.
+* `num_thread 24` in the `Modelfile` to fully utilise the CPU when generating responses.
+
+These values can be tweaked further depending on your exact workload and resource availability.
 
 Usage
 -----

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     environment:
       - OLLAMA_MODEL_PATH=/root/.ollama/models
       - OLLAMA_HOST=0.0.0.0
-      - OLLAMA_NUM_THREADS=16
+      - OLLAMA_NUM_THREADS=24
       - OLLAMA_KEEP_ALIVE=10m  
       - OLLAMA_GPU_LAYERS=32    # This may work as an environment variable even if not as a model parameter
       - OLLAMA_PARALLEL=2       # This may work as an environment variable
@@ -64,7 +64,7 @@ services:
       - EMBEDDING_DIMENSIONS=768
       - EMBEDDING_BATCH_SIZE=64
       # Performance optimizations
-      - WEBUI_WORKERS=4
+      - WEBUI_WORKERS=12
     networks:
       - jarvis-net
 

--- a/document_processor.py
+++ b/document_processor.py
@@ -33,8 +33,10 @@ logging.basicConfig(
 )
 logger = logging.getLogger("DocumentProcessor")
 
-# Load NLP model
+# Load NLP model with optional GPU support
 try:
+    # Prefer running on GPU if available to speed up processing
+    spacy.prefer_gpu()
     nlp = spacy.load("en_core_web_lg")
     logger.info("Loaded spaCy NLP model successfully")
 except Exception as e:


### PR DESCRIPTION
## Summary
- enable spaCy GPU acceleration in document processor
- allocate more threads and workers for high-end hardware
- bump LLM thread settings
- document hardware tuning instructions

## Testing
- `python -m py_compile document_processor.py hybrid_search/hybrid_search.py hybrid_search/api.py proxy/ollama_proxy.py proxy/hybrid_search.py`

## Summary by Sourcery

Enable spaCy GPU support, increase thread and worker defaults for high-end hardware, and add README guidance for optimizing dual-GPU systems.

New Features:
- Enable GPU acceleration in the document processor.

Enhancements:
- Increase default CPU thread counts in docker-compose and Modelfile for better performance.
- Raise web UI worker count in docker-compose for improved concurrency.

Documentation:
- Document hardware tuning instructions for dual V100 GPU setups.