### PR TITLE
Fix missing import and timestamp method

### DIFF
--- a/hybrid_search/api.py
+++ b/hybrid_search/api.py
@@ -1,5 +1,6 @@
 from flask import Flask, request, jsonify
 from hybrid_search import HybridSearch
+import requests
 
 app = Flask(__name__)
 

--- a/hybrid_search/hybrid_search.py
+++ b/hybrid_search/hybrid_search.py
@@ -43,10 +43,15 @@ class HybridSearch:
         # Ollama connection for embeddings
         self.ollama_url = ollama_url
         self.model = "nomic-embed-text"
-        
+
         # Cache for available knowledge bases
         self.kb_cache = {}
         self.refresh_kb_cache()
+
+    def get_timestamp(self):
+        """Return an ISO formatted timestamp."""
+        from datetime import datetime
+        return datetime.now().isoformat()
     
     def refresh_kb_cache(self):
         """Refresh the cache of available knowledge bases"""


### PR DESCRIPTION
## Summary
- add missing `requests` import in `hybrid_search/api.py`
- provide `get_timestamp` helper in `HybridSearch`

## Testing
- `python -m py_compile document_processor.py hybrid_search/hybrid_search.py hybrid_search/api.py proxy/ollama_proxy.py proxy/hybrid_search.py`
- `pytest -q` *(fails: command not found)*

## Summary by Sourcery

Add missing requests import to the API module and implement get_timestamp helper in HybridSearch

Bug Fixes:
- Add missing requests import in hybrid_search/api.py

Enhancements:
- Add get_timestamp method to HybridSearch for ISO formatted timestamps