### PR TITLE
Fix environment variable mismatch and tidy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ JarvisAI is a powerful self-hosted Retrieval-Augmented Generation (RAG) system t
 
 **Note:** JarvisAI is designed to run on systems with NVIDIA GPUs (particularly V100) for optimal performance.
 
-=======
 ### 🚀 Quick Start
 
 To get started with JarvisAI, simply run:
@@ -17,9 +16,6 @@ To get started with JarvisAI, simply run:
 
 The start.sh script will automatically check requirements, install dependencies, and launch the complete JarvisAI system.
 
-**Note:** JarvisAI is designed to run on systems with NVIDIA GPUs (particularly V100) for optimal performance.
-
-User OpenWebUI Ollama Proxy Ollama LLM Document Processor Neo4j Milvus etcd/MinIO Document Storage & Knowledge Base Legend Services Graph DB Vector DB
 
 
 Table of Contents
@@ -197,6 +193,7 @@ JarvisAI has the following hardware and software requirements:
 *   Docker and Docker Compose (v2.x+)
 *   NVIDIA Container Toolkit (for GPU access in containers)
 *   Git (for repository cloning)
+*   Python 3.10 or newer (for the document processor)
 
 Installation
 ------------
@@ -638,7 +635,4 @@ JarvisAI can be extended in several ways:
 *   Integrating with other LLM providers
 *   Adding visualization capabilities for the knowledge graph
 
-JarvisAI - A Self-Hosted RAG System with Knowledge Graph
-
-=======
 Created by [AnubissBE](https://github.com/AnubissBE)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -207,7 +207,7 @@ services:
       - ./jarvis_kb_config.env
     environment:
       - NEO4J_URI=bolt://neo4j:7687
-      - NEO4J_USERNAME=neo4j
+      - NEO4J_USER=neo4j
       - NEO4J_PASSWORD=VerySecurePassword
       - MILVUS_HOST=milvus-standalone
       - MILVUS_PORT=19530

--- a/hybrid_search/hybrid_search.py
+++ b/hybrid_search/hybrid_search.py
@@ -155,8 +155,8 @@ class HybridSearch:
                       'than', 'too', 'very', 's', 't', 'can', 'will', 'just', 'don',
                       'should', 'now', 'd', 'll', 'm', 'o', 're', 've', 'y', 'ain', 'aren',
                       'couldn', 'didn', 'doesn', 'hadn', 'hasn', 'haven', 'isn', 'ma',
-                      'mightn', 'mustn', 'needn', 'shan', 'shouldn', 'wasn', 'weren', 'won',
-                      'wouldn', 'I', 'you', 'he', 'she', 'it', 'we', 'they', 'what', 'who'}
+                     'mightn', 'mustn', 'needn', 'shan', 'shouldn', 'wasn', 'weren', 'won',
+                     'wouldn', 'i', 'you', 'he', 'she', 'it', 'we', 'they', 'what', 'who'}
         
         terms = [word for word in words if word not in stop_words and len(word) > 2]
         


### PR DESCRIPTION
## Summary
- clean up README formatting
- mention Python 3.10 requirement
- fix docker-compose env var name
- correct stop words case in hybrid_search

## Testing
- `python -m py_compile $(git ls-files '*.py')`

## Summary by Sourcery

Fix environment variable mismatch and stop word casing issues, and tidy up README with formatting cleanup and updated Python requirement.

Bug Fixes:
- Correct NEO4J env var name in docker-compose from NEO4J_USERNAME to NEO4J_USER
- Normalize pronoun stop words to lowercase in hybrid_search

Documentation:
- Cleanup stray formatting markers and duplicate notes in README
- Add Python 3.10 requirement to README