### PR TITLE
Fix OpenWebUI search method

### DIFF
--- a/proxy/hybrid_search.py
+++ b/proxy/hybrid_search.py
@@ -123,7 +123,7 @@ class HybridSearch:
         api_url = "http://open-webui:8080/api/v1/knowledge/query"
         
         try:
-            response = requests.get(
+            response = requests.post(
                 api_url,
                 json={
                     "query": query_text,


### PR DESCRIPTION
## Summary
- update `search_milvus_via_openwebui` to POST instead of GET

## Testing
- `python -m py_compile proxy/hybrid_search.py`
- `pytest -q` *(fails: command not found)*

## Summary by Sourcery

Bug Fixes:
- Use POST requests for the OpenWebUI search API call instead of GET