### PR TITLE
Fix pytextract decoding for document processor

### DIFF
--- a/document_processor.py
+++ b/document_processor.py
@@ -218,7 +218,19 @@ class DocumentProcessor:
                 logger.warning("pytextract not available, cannot handle file: %s", file_path)
                 return ""
             try:
-                return pytextract.process(file_path).strip()
+                raw_content = pytextract.process(file_path)
+                try:
+                    text = (
+                        raw_content.decode("utf-8", errors="ignore")
+                        if isinstance(raw_content, (bytes, bytearray))
+                        else str(raw_content)
+                    )
+                    return text.strip()
+                except Exception as decode_error:
+                    logger.error(
+                        f"Error decoding extracted text: {str(decode_error)}"
+                    )
+                    return ""
             except Exception as e:
                 logger.error(f"Error extracting text with pytextract: {str(e)}")
                 return ""


### PR DESCRIPTION
## Summary
- properly decode bytes returned from `pytextract.process`
- add error handling when decoding fails

## Testing
- `python -m py_compile document_processor.py`

## Summary by Sourcery

Improve document text extraction by properly decoding raw outputs from pytextract and adding error handling for decoding failures

Bug Fixes:
- Catch and log exceptions during decoding of extracted text and return an empty string on failure

Enhancements:
- Conditionally decode byte or bytearray outputs from pytextract into UTF-8 strings while stripping whitespace
- Convert non-byte outputs to strings before stripping