### PR TITLE
Add logs and debug options

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,11 @@ Simply make the script executable and run it:
     ./start.sh
 
 The script will guide you through the entire process with clear, color-coded output.
+You can also run the script with extra options:
+
+    ./start.sh --logs    # View Docker container logs
+    ./start.sh --debug   # Enable verbose output and display error codes
+
 
 ### CPU-Only Mode
 


### PR DESCRIPTION
## Summary
- add command line parsing for `--logs` and `--debug` in `start.sh`
- update README with usage of new options

## Testing
- `bash -n start.sh`
- `python -m py_compile document_processor.py hybrid_search/hybrid_search.py`

## Summary by Sourcery

Add log viewing and debug modes to start.sh, improve Modelfile newline handling, and update documentation accordingly

New Features:
- Add --logs/-l flag to stream Docker container logs from the startup script
- Add --debug/-d flag to enable verbose output and immediate exit on errors in the startup script

Enhancements:
- Preserve actual newlines when encoding Modelfile contents for the API in setup_jarvis_model

Documentation:
- Document the new --logs and --debug options in README