### PR TITLE
Fix Jarvis model setup and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ ollama pull llama3.1:8b
 ollama pull nomic-embed-text
 ```
 
-The [`start.sh`](start.sh) script automatically pulls `llama3.1:8b` when creating the `jarvis` model as shown in the script:
+The [`start.sh`](start.sh) script automatically pulls `llama3.1:8b` and `nomic-embed-text` when creating the `jarvis` model as shown in the script:
 ```
 curl -X POST "http://localhost:11434/api/pull" \
     -H "Content-Type: application/json" \


### PR DESCRIPTION
## Summary
- add automatic pull of nomic-embed-text in `start.sh`
- improve Modelfile upload by converting newlines to spaces
- document that the setup script pulls both required models

## Testing
- `bash -n start.sh`

## Summary by Sourcery

Add automatic pulling of the nomic-embed-text model with retry logic, simplify Modelfile payload encoding by converting newlines to spaces, and update documentation to reflect both required models being fetched.

New Features:
- Automatically pull nomic-embed-text model with retry logic in start.sh

Enhancements:
- Convert Modelfile newlines to spaces and escape quotes for robust JSON payloads

Documentation:
- Update README to note that start.sh pulls both llama3.1:8b and nomic-embed-text models