### PR TITLE
Fix CPU mode and proxy port

### DIFF
--- a/proxy/ollama_proxy.py
+++ b/proxy/ollama_proxy.py
@@ -99,4 +99,5 @@ def proxy(path):
     )
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000)
+    # Run on the same port exposed by the Docker container
+    app.run(host='0.0.0.0', port=11435)

--- a/start.sh
+++ b/start.sh
@@ -331,7 +331,8 @@ start_jarvisai() {
     else
         echo -e "${YELLOW}Starting in CPU-only mode (performance will be limited)...${NC}"
         # Remove GPU-specific configurations when running without GPU
-        sed 's/driver: nvidia/driver: none/g' docker-compose.yml > docker-compose-cpu.yml
+        # Strip GPU-specific settings for CPU-only environments
+        sed '/driver: nvidia/d;/capabilities: \[gpu\]/d;/count: .*/d' docker-compose.yml > docker-compose-cpu.yml
         docker-compose -f docker-compose-cpu.yml up -d
     fi
     


### PR DESCRIPTION
## Summary
- fix open proxy to run on port 11435
- remove GPU-only sections when generating CPU docker compose file

## Testing
- `python -m py_compile document_processor.py hybrid_search/hybrid_search.py proxy/ollama_proxy.py hybrid_search/api.py`
- `bash -n start.sh`

## Summary by Sourcery

Change proxy service port to match Docker container and refine CPU-only Docker Compose file generation by removing all GPU-specific configurations.

Bug Fixes:
- Run the proxy on port 11435 to align with the exposed Docker port.

Enhancements:
- Strip GPU-specific settings (driver, capabilities, count) when generating the CPU-only Docker Compose file.