### PR TITLE
Fix env file names and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ JarvisAI is a powerful self-hosted Retrieval-Augmented Generation (RAG) system t
 
 ### 🚀 Quick Start
 
-To get started with JarvisAI, simply run:
+To get started with JarvisAI on a fresh Ubuntu 22.04 server, run:
 
     git clone https://github.com/AnubissBE/jarvisai.git
     cd jarvisai
     chmod +x start.sh
     ./start.sh
 
-The start.sh script will automatically check requirements, install dependencies, and launch the complete JarvisAI system.
+The `start.sh` script installs Docker if needed and launches all containers in one go. No additional configuration is required.
 
 
 
@@ -182,10 +182,10 @@ JarvisAI has the following hardware and software requirements:
 
 ### Hardware Requirements
 
-*   NVIDIA GPUs (2× V100 recommended) for optimal performance
-*   Minimum 32GB RAM (64GB recommended)
-*   100GB+ storage space
-*   Fast internet connection for model downloads
+*   Two NVIDIA V100 GPUs (16GB each)
+*   Dual Xeon CPUs
+*   256GB RAM
+*   10TB of storage
 
 ### Software Requirements
 
@@ -300,6 +300,12 @@ Configuration
 
 The main system configuration is in `docker-compose.yml` and `jarvis_kb_config.env`. Key configuration options include:
 
+#### Database Connection Settings
+
+* `NEO4J_URI` – address of the Neo4j database
+* `NEO4J_USER` / `NEO4J_PASSWORD` – credentials for Neo4j
+* `MILVUS_HOST` / `MILVUS_PORT` – location of the Milvus vector store
+
 #### Ollama Settings
 
 *   `OLLAMA_NUM_PARALLEL`: Number of parallel requests allowed (default: 4)
@@ -346,7 +352,7 @@ The LLM is configured in the `Modelfile`. You can modify this file to change LLM
 For systems with two NVIDIA V100 GPUs and high core-count CPUs, adjust the following settings for best performance:
 
 * `OLLAMA_NUM_THREADS=24` in `docker-compose.yml` to match the available CPU threads.
-* `WEBUI_WORKERS=12` in `docker-compose.yml` for improved concurrency in the web interface.
+* `WEBUI_WORKERS=24` in `docker-compose.yml` for improved concurrency in the web interface.
 * `num_thread 24` in the `Modelfile` to fully utilise the CPU when generating responses.
 
 These values can be tweaked further depending on your exact workload and resource availability.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       - EMBEDDING_DIMENSIONS=768
       - EMBEDDING_BATCH_SIZE=64
       # Performance optimizations
-      - WEBUI_WORKERS=12
+      - WEBUI_WORKERS=24
     networks:
       - jarvis-net
 
@@ -206,11 +206,6 @@ services:
     env_file:
       - ./jarvis_kb_config.env
     environment:
-      - NEO4J_URI=bolt://neo4j:7687
-      - NEO4J_USER=neo4j
-      - NEO4J_PASSWORD=VerySecurePassword
-      - MILVUS_HOST=milvus-standalone
-      - MILVUS_PORT=19530
       - EMBEDDING_ENDPOINT=http://ollama:11434
       - EMBEDDING_MODEL=nomic-embed-text
       - LOG_LEVEL=info

--- a/jarvis_kb_config.env
+++ b/jarvis_kb_config.env
@@ -1,12 +1,12 @@
 # Jarvis Knowledge Base Configuration
 
 # Docker Compose Environment Variables for the document processor service
-JARVIS_NEO4J_URI=bolt://neo4j:7687
-JARVIS_NEO4J_USER=neo4j
-JARVIS_NEO4J_PASSWORD=VerySecurePassword
-JARVIS_MILVUS_HOST=milvus-standalone
-JARVIS_MILVUS_PORT=19530
-JARVIS_OLLAMA_URL=http://ollama:11434
+NEO4J_URI=bolt://neo4j:7687
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=VerySecurePassword
+MILVUS_HOST=milvus-standalone
+MILVUS_PORT=19530
+OLLAMA_URL=http://ollama:11434
 
 # OpenWebUI Uploads directory
 UPLOADS_DIR=/app/backend/data/uploads


### PR DESCRIPTION
## Summary
- update environment variable names in `jarvis_kb_config.env`
- streamline docker-compose configuration for document processor
- bump WEBUI workers for higher spec hardware
- refresh README with zero‑config quick start and updated hardware section

## Testing
- `python3 -m py_compile document_processor.py proxy/ollama_proxy.py hybrid_search/hybrid_search.py`
