### PR TITLE
Add pymilvus to proxy requirements

### DIFF
--- a/proxy/requirements.txt
+++ b/proxy/requirements.txt
@@ -1,3 +1,5 @@
 flask==3.1.1
 requests==2.31.0
 neo4j==5.28.1
+
+pymilvus==2.3.3


### PR DESCRIPTION
## Summary
- add `pymilvus==2.3.3` to proxy requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `docker build ./proxy -t jarvisai-proxy:test` *(fails: `docker` command not found)*

## Summary by Sourcery

Enhancements:
- Include pymilvus==2.3.3 in proxy/requirements.txt