### PR TITLE
Update README for OLLAMA_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ The main system configuration is in `docker-compose.yml` and `jarvis_kb_config.e
 *   `ENABLE_KB_DISCOVERY`: Automatically discover knowledge bases (default: true)
 *   `ENABLE_MULTI_KB_SEARCH`: Search across multiple knowledge bases (default: true)
 *   `MAX_RESULTS_PER_KB`: Maximum results per knowledge base (default: 5)
+*   `OLLAMA_URL`: Base URL for the embedding service used by the document processor
 
 ### LLM Configuration
 


### PR DESCRIPTION
## Summary
- document OLLAMA_URL for document processor embeddings

## Testing
- `python -m py_compile document_processor.py hybrid_search/*.py`

## Summary by Sourcery

Documentation:
- Add `OLLAMA_URL` description to README for embedding service configuration