### PR TITLE
Document env vars

### DIFF
--- a/jarvis_kb_config.env
+++ b/jarvis_kb_config.env
@@ -4,8 +4,12 @@
 NEO4J_URI=bolt://neo4j:7687
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=VerySecurePassword
+
+# Milvus vector store connection
 MILVUS_HOST=milvus-standalone
 MILVUS_PORT=19530
+
+# Base URL for the Ollama API
 OLLAMA_URL=http://ollama:11434
 
 # OpenWebUI Uploads directory


### PR DESCRIPTION
## Summary
- comment MILVUS and OLLAMA variables in the env file

## Testing
- `python3 -m py_compile document_processor.py hybrid_search/hybrid_search.py proxy/ollama_proxy.py`

## Summary by Sourcery

Documentation:
- Comment out MILVUS and OLLAMA variables in jarvis_kb_config.env