### PR TITLE
Load service URLs from environment

### DIFF
--- a/document_processor.py
+++ b/document_processor.py
@@ -2,6 +2,9 @@
 import os
 import time
 import hashlib
+MILVUS_HOST=os.getenv("MILVUS_HOST","milvus-standalone")
+MILVUS_PORT=os.getenv("MILVUS_PORT","19530")
+OLLAMA_URL=os.getenv("OLLAMA_URL","http://ollama:11434")
 try:
     import spacy
 except ImportError:  # pragma: no cover - optional dependency
@@ -86,9 +89,9 @@ class DocumentProcessor:
         self.neo4j_uri = os.environ.get("NEO4J_URI", "bolt://neo4j:7687")
         self.neo4j_user = os.environ.get("NEO4J_USER", "neo4j")
         self.neo4j_password = os.environ.get("NEO4J_PASSWORD", "VerySecurePassword")
-        self.milvus_host = os.getenv("MILVUS_HOST", "milvus-standalone")
-        self.milvus_port = os.getenv("MILVUS_PORT", "19530")
-        self.ollama_url = os.getenv("OLLAMA_URL", "http://ollama:11434")
+        self.milvus_host = MILVUS_HOST
+        self.milvus_port = MILVUS_PORT
+        self.ollama_url = OLLAMA_URL
         self.uploads_dir = os.environ.get("UPLOADS_DIR", "/app/backend/data/uploads")
         self.processed_dir = os.environ.get("PROCESSED_DIR", "/processed")
         self.config_dir = os.environ.get("CONFIG_DIR", "/app/config")


### PR DESCRIPTION
## Summary
- read MILVUS_HOST, MILVUS_PORT and OLLAMA_URL at module import
- inject them when creating `HybridSearch`

## Testing
- `python -m py_compile document_processor.py hybrid_search/hybrid_search.py`

## Summary by Sourcery

Centralize loading of MILVUS and OLLAMA service endpoints from environment variables and inject them into the document processor initialization

Enhancements:
- Read MILVUS_HOST, MILVUS_PORT, and OLLAMA_URL once at module import instead of per-instance
- Update DocumentProcessor to use the module-level constants for milvus_host, milvus_port, and ollama_url