### PR TITLE
Add numpy to proxy requirements

### DIFF
--- a/proxy/requirements.txt
+++ b/proxy/requirements.txt
@@ -3,3 +3,4 @@ requests==2.31.0
 neo4j==5.28.1
 
 pymilvus==2.3.3
+numpy


### PR DESCRIPTION
## Summary
- include numpy dependency for proxy

## Testing
- `python3 -m py_compile document_processor.py hybrid_search/__init__.py hybrid_search/api.py hybrid_search/hybrid_search.py hybrid_search/testneo.py proxy/fix_openwebui_url.py proxy/hybrid_search.py proxy/ollama_proxy.py`

## Summary by Sourcery

Build:
- Add numpy to proxy/requirements.txt