### PR TITLE
Update Ollama URL description

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ The main system configuration is in `docker-compose.yml` and `jarvis_kb_config.e
 
 #### Ollama Settings
 
-* `OLLAMA_URL` – base URL for the Ollama API
+* `OLLAMA_URL` – base URL used by the document processor for embeddings
 *   `OLLAMA_NUM_PARALLEL`: Number of parallel requests allowed (default: 4)
 *   `OLLAMA_MAX_LOADED_MODELS`: Maximum models to keep loaded (default: 2)
 *   `OLLAMA_CONTEXT_LENGTH`: Maximum context length (default: 262144)


### PR DESCRIPTION
## Summary
- clarify usage for `OLLAMA_URL` in the Ollama settings

## Testing
- `git status --short`