### PR TITLE
Fix installation numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,8 +273,7 @@ EMBEDDING_MODEL=nomic-embed-text
 
 **Warning:** Initial startup may take considerable time (30+ minutes) as models are downloaded and containers are initialized.
 
-### Step 4: Verify Installation
-#### Step 4: Create the Jarvis Model
+### Step 4: Create the Jarvis Model
 
 Wait for Ollama to start, then create the Jarvis model:
 
@@ -282,7 +281,7 @@ Wait for Ollama to start, then create the Jarvis model:
         -H "Content-Type: application/json" \
         -d "{\"name\": \"jarvis\", \"modelfile\": \"$(cat Modelfile | sed 's/"/\\"/g' | tr '\n' ' ')\"}"
 
-#### Step 5: Verify Installation
+### Step 5: Verify Installation
 
 Check if all services are running properly:
 


### PR DESCRIPTION
## Summary
- correct installation step numbers so Jarvis model is created in step 4
- move verification into step 5

## Testing
- `python3 -m py_compile document_processor.py hybrid_search/api.py hybrid_search/testneo.py hybrid_search/hybrid_search.py proxy/ollama_proxy.py proxy/fix_openwebui_url.py proxy/hybrid_search.py`

## Summary by Sourcery

Correct installation step numbering in README to set model creation as step 4 and move verification to step 5.

Documentation:
- Rename Step 4 to 'Create the Jarvis Model' in the README.
- Shift the verification instructions to Step 5 in the README.