### PR TITLE
Replace repo URL placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Installation
 
 ### Step 1: Clone the Repository
 
-    git clone https://github.com/yourusername/jarvisai.git
+    git clone https://github.com/AnubissBE/jarvisai.git
     cd jarvisai
 
 ### Step 2: Set Up Environment Variables


### PR DESCRIPTION
## Summary
- update README with real repo URL

## Testing
- `python -m py_compile $(git ls-files '*.py')`

## Summary by Sourcery

Documentation:
- Replace the placeholder GitHub repository URL in README with the actual 'AnubissBE/jarvisai' URL.