### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,35 @@
+# Ignore volume directories and logs
+volumes/
+logs/
+
+# Python cache and compiled files
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Environment and virtualenv directories
+.env
+.venv
+env/
+venv/
+ENV/
+
+# Database and log files
+*.db
+*.sqlite
+*.sqlite3
+*.log
+
+# Configuration files containing secrets
+config/kb_default_config.json
+
+# Docker volumes
+docker-volumes/
+
+# OS generated files
+.DS_Store
+
+# Optional editor directories
+.vscode/
+.idea/


### PR DESCRIPTION
## Summary
- exclude non-code files from Docker build context

## Testing
- `python3 -m py_compile document_processor.py proxy/ollama_proxy.py hybrid_search/hybrid_search.py hybrid_search/api.py hybrid_search/__init__.py hybrid_search/testneo.py`

## Summary by Sourcery

Enhancements:
- Introduce .dockerignore to streamline Docker image builds by omitting irrelevant files