### PR TITLE
Make WEBUI_WORKERS configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ The LLM is configured in the `Modelfile`. You can modify this file to change LLM
 For systems with two NVIDIA V100 GPUs and high core-count CPUs, adjust the following settings for best performance:
 
 * `OLLAMA_NUM_THREADS=24` in `docker-compose.yml` to match the available CPU threads.
-* `WEBUI_WORKERS=24` in `docker-compose.yml` for improved concurrency in the web interface.
+* `WEBUI_WORKERS=${WEBUI_WORKERS:-4}` in `docker-compose.yml` for improved concurrency in the web interface (adjust the `WEBUI_WORKERS` environment variable to tune performance).
 * `num_thread 24` in the `Modelfile` to fully utilise the CPU when generating responses.
 
 These values can be tweaked further depending on your exact workload and resource availability.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       - EMBEDDING_DIMENSIONS=768
       - EMBEDDING_BATCH_SIZE=64
       # Performance optimizations
-      - WEBUI_WORKERS=24
+      - WEBUI_WORKERS=${WEBUI_WORKERS:-4}
     networks:
       - jarvis-net
 


### PR DESCRIPTION
## Summary
- allow WebUI worker count to be configured via environment variable
- document the `WEBUI_WORKERS` setting in performance tuning

## Testing
- `python3 -m py_compile $(find . -name '*.py')`
- `shellcheck start.sh` *(fails: command not found)*
- `docker-compose config` *(fails: command not found)*

## Summary by Sourcery

Enable runtime configuration of WebUI worker count by replacing hardcoded values with the WEBUI_WORKERS environment variable and update documentation accordingly.

Enhancements:
- Allow configuring the number of WEBUI workers via the WEBUI_WORKERS environment variable
- Set the default WEBUI_WORKERS value to 4 when the environment variable is not provided

Documentation:
- Update README to document the WEBUI_WORKERS environment variable for performance tuning