### PR TITLE
Add SPACY_MODEL variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ The main system configuration is in `docker-compose.yml` and `jarvis_kb_config.e
 *   `ENABLE_MULTI_KB_SEARCH`: Search across multiple knowledge bases (default: true)
 *   `MAX_RESULTS_PER_KB`: Maximum results per knowledge base (default: 5)
 *   `OLLAMA_URL`: Base URL for the embedding service used by the document processor
+*   `SPACY_MODEL`: spaCy language model to load (default: `en_core_web_lg`)
 
 ### LLM Configuration
 

--- a/document_processor.py
+++ b/document_processor.py
@@ -5,6 +5,7 @@ import hashlib
 MILVUS_HOST=os.getenv("MILVUS_HOST","milvus-standalone")
 MILVUS_PORT=os.getenv("MILVUS_PORT","19530")
 OLLAMA_URL=os.getenv("OLLAMA_URL","http://ollama:11434")
+SPACY_MODEL=os.getenv("SPACY_MODEL","en_core_web_lg")
 try:
     import spacy
 except ImportError:  # pragma: no cover - optional dependency
@@ -77,7 +78,7 @@ if spacy is not None:
     try:
         # Prefer running on GPU if available
         spacy.prefer_gpu()
-        nlp = spacy.load("en_core_web_lg")
+        nlp = spacy.load(SPACY_MODEL)
         logger.info("Loaded spaCy NLP model successfully")
     except Exception as e:
         logger.error(f"Error loading spaCy model: {str(e)}")

--- a/jarvis_kb_config.env
+++ b/jarvis_kb_config.env
@@ -12,6 +12,9 @@ MILVUS_PORT=19530
 # Base URL for the Ollama API
 OLLAMA_URL=http://ollama:11434
 
+# spaCy language model used by the document processor
+SPACY_MODEL=en_core_web_lg
+
 # OpenWebUI Uploads directory
 UPLOADS_DIR=/app/backend/data/uploads
 


### PR DESCRIPTION
## Summary
- allow overriding spaCy model via `SPACY_MODEL` env var
- document the variable in README and env sample

## Testing
- `python3 -m py_compile document_processor.py`
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*

## Summary by Sourcery

Introduce SPACY_MODEL env var to specify the spaCy model dynamically and update documentation accordingly

New Features:
- Allow overriding the spaCy language model via a new SPACY_MODEL environment variable

Documentation:
- Document the SPACY_MODEL variable in README and sample env file