### PR TITLE
Fix OPENWEBUI_API_BASE_URL scope

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,6 @@ services:
       - WEBUI_SECRET_KEY=${WEBUI_SECRET_KEY:-your_secure_secret_key_here}
 
       # API Configuration
-      - OPENWEBUI_API_BASE_URL=http://open-webui:8080
 
       # RAG Configuration
       - ENABLE_RAG=True


### PR DESCRIPTION
## Summary
- remove `OPENWEBUI_API_BASE_URL` from OpenWebUI environment
- keep proxy environment unchanged

## Testing
- `docker` *(fails: command not found)*