### PR TITLE
Update default OpenWebUI URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ The main system configuration is in `docker-compose.yml` and `jarvis_kb_config.e
 
 #### Proxy Settings
 
-* `OPENWEBUI_API_BASE_URL`: Base URL for the OpenWebUI API used by the hybrid search proxy
+* `OPENWEBUI_API_BASE_URL`: Base URL for the OpenWebUI API used by the hybrid search proxy (default: `http://open-webui:8080`)
 
 ### LLM Configuration
 


### PR DESCRIPTION
## Summary
- mention default `OPENWEBUI_API_BASE_URL` in docs

## Testing
- `python -m compileall -q .`

## Summary by Sourcery

Documentation:
- Mention default OPENWEBUI_API_BASE_URL (`http://open-webui:8080`) in the README documentation