### PR TITLE
Unify log directory variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ The main system configuration is in `docker-compose.yml` and `jarvis_kb_config.e
 *   `MAX_RESULTS_PER_KB`: Maximum results per knowledge base (default: 5)
 *   `OLLAMA_URL`: Base URL for the embedding service used by the document processor
 *   `SPACY_MODEL`: spaCy language model to load (default: `en_core_web_lg`)
+*   `LOG_DIR`: Directory where the document processor writes logs (default: `./logs`)
 
 #### Proxy Settings
 

--- a/document_processor.py
+++ b/document_processor.py
@@ -54,7 +54,7 @@ from hybrid_search import HybridSearch
 # Determine repository root for logs
 repo_root = os.path.dirname(os.path.abspath(__file__))
 # Log directory can be overridden via env var, default to repo/logs
-log_dir = os.environ.get("JARVIS_LOG_DIR", os.path.join(repo_root, "logs"))
+log_dir = os.environ.get("LOG_DIR", os.path.join(repo_root, "logs"))
 os.makedirs(log_dir, exist_ok=True)
 
 # Configure logging with fallback if file handler fails


### PR DESCRIPTION
## Summary
- use `LOG_DIR` consistently in `document_processor.py`
- document `LOG_DIR` in the README

## Testing
- `python3 -m py_compile document_processor.py`
- `docker-compose -f docker-compose.yml config` *(fails: command not found)*

## Summary by Sourcery

Unify the log directory environment variable by replacing JARVIS_LOG_DIR with LOG_DIR in the document processor and update README to document the new LOG_DIR setting.

Enhancements:
- Use LOG_DIR instead of JARVIS_LOG_DIR to specify the log directory in document_processor.py

Documentation:
- Add LOG_DIR description to README with default value