### PR TITLE
Update README document processing config

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,12 @@ The main system configuration is in `docker-compose.yml` and `jarvis_kb_config.e
 *   `MAX_RESULTS_PER_KB`: Maximum results per knowledge base (default: 5)
 *   `OLLAMA_URL`: Base URL for the embedding service used by the document processor
 *   `SPACY_MODEL`: spaCy language model to load (default: `en_core_web_lg`)
+*   `DOCUMENT_CHUNK_SIZE`: Number of characters per chunk when splitting documents (default: 1536)
+*   `DOCUMENT_CHUNK_OVERLAP`: Number of overlapping characters between chunks (default: 256)
+*   `PROCESSING_BATCH_SIZE`: How many chunks to embed at once (default: 16)
+*   `PROCESSED_DIR`: Directory where processed documents are stored (default: `/processed`)
+*   `CONFIG_DIR`: Directory for persistent configuration files (default: `/app/config`)
+*   `JARVIS_LOG_DIR`: Directory for document processor logs (default: `<repo>/logs`)
 
 #### Proxy Settings
 

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ The main system configuration is in `docker-compose.yml` and `jarvis_kb_config.e
 *   `PROCESSING_BATCH_SIZE`: How many chunks to embed at once (default: 16)
 *   `PROCESSED_DIR`: Directory where processed documents are stored (default: `/processed`)
 *   `CONFIG_DIR`: Directory for persistent configuration files (default: `/app/config`)
-*   `JARVIS_LOG_DIR`: Directory for document processor logs (default: `<repo>/logs`)
+*   `JARVIS_LOG_DIR`: Directory for document processor logs (default: `<repo>/logs`, where `<repo>` refers to the root directory of the cloned repository or the application’s working directory inside the container)
 
 #### Proxy Settings
 


### PR DESCRIPTION
## Summary
- expand Document Processing Settings in the README with explanations for chunk size, chunk overlap, batch size, processed/config directories and log directory

## Testing
- `python3 document_processor.py --help` *(fails: starts processor and produces log output)*

## Summary by Sourcery

Documentation:
- Add detailed explanations for document processing options including chunk size, chunk overlap, batch size, processed/config directories, and log directory.