### PR TITLE
Add MIT license and reference

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 AnubissBE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -669,4 +669,8 @@ JarvisAI can be extended in several ways:
 *   Integrating with other LLM providers
 *   Adding visualization capabilities for the knowledge graph
 
+### License
+
+JarvisAI is distributed under the [MIT License](LICENSE).
+
 Created by [AnubissBE](https://github.com/AnubissBE)


### PR DESCRIPTION
## Summary
- add standard MIT License text
- document license in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

## Summary by Sourcery

Add MIT License to the project

Documentation:
- Add MIT License text file
- Reference the MIT License in the README