### PR TITLE
Ensure hybrid_search import

### DIFF
--- a/document_processor.py
+++ b/document_processor.py
@@ -45,6 +45,11 @@ except ImportError:  # pragma: no cover - optional dependency
     Collection = None
     utility = None
 
+# Ensure the packaged hybrid_search module is discoverable
+jarvis_path = "/opt/jarvis"
+if jarvis_path not in sys.path:
+    sys.path.insert(0, jarvis_path)
+
 # Ensure repository root is in import path
 repo_root = os.path.dirname(os.path.abspath(__file__))
 if repo_root not in sys.path:

--- a/hybrid_search/__init__.py
+++ b/hybrid_search/__init__.py
@@ -1,3 +1,3 @@
 from .hybrid_search import HybridSearch
 
-__all__ = ['HybridSearch']
+__all__ = ["HybridSearch"]


### PR DESCRIPTION
## Summary
- update path for `HybridSearch` import
- normalize `hybrid_search.__init__`

## Testing
- `python -m py_compile document_processor.py hybrid_search/*.py`

## Summary by Sourcery

Ensure the hybrid_search package is discoverable and simplify its initialization

Bug Fixes:
- Prepend "/opt/jarvis" to sys.path in document_processor.py to enable hybrid_search imports

Enhancements:
- Remove explicit __all__ declaration in hybrid_search/__init__.py, normalizing the module’s export