### PR TITLE
Fix Ollama env variable name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -211,7 +211,7 @@ services:
     env_file:
       - ./jarvis_kb_config.env
     environment:
-      - EMBEDDING_ENDPOINT=http://ollama:11434
+      - OLLAMA_URL=http://ollama:11434
       - EMBEDDING_MODEL=nomic-embed-text
       - LOG_LEVEL=info
       - DOCUMENT_CHUNK_SIZE=1536


### PR DESCRIPTION
## Summary
- rename `EMBEDDING_ENDPOINT` to `OLLAMA_URL` in docker-compose file

## Testing
- `python3 -m py_compile document_processor.py`