### PR TITLE
Fix proxy Dockerfile dependency versions

### DIFF
--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -8,7 +8,7 @@ RUN pip install --no-cache-dir \
     environs==9.5.0
 
 # Install dependencies with specific versions for consistency
-RUN pip install --no-cache-dir flask==2.3.3 requests==2.31.0 neo4j==5.12.0 pymilvus==2.3.3
+RUN pip install --no-cache-dir flask==3.1.1 requests==2.31.0 neo4j==5.28.1 pymilvus==2.3.3
 
 # Copy application code
 COPY . .


### PR DESCRIPTION
## Summary
- align proxy Dockerfile with requirements

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`

## Summary by Sourcery

Build:
- Update proxy Dockerfile to use flask==3.1.1 and neo4j==5.28.1 for consistency