### PR TITLE
Clean up unused KB search env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,9 +320,6 @@ The main system configuration is in `docker-compose.yml` and `jarvis_kb_config.e
 
 #### Document Processing Settings
 
-*   `ENABLE_KB_DISCOVERY`: Automatically discover knowledge bases (default: true)
-*   `ENABLE_MULTI_KB_SEARCH`: Search across multiple knowledge bases (default: true)
-*   `MAX_RESULTS_PER_KB`: Maximum results per knowledge base (default: 5)
 *   `OLLAMA_URL`: Base URL for the embedding service used by the document processor
 *   `SPACY_MODEL`: spaCy language model to load (default: `en_core_web_lg`)
 *   `LOG_DIR`: Directory where the document processor writes logs (default: `./logs`)

--- a/jarvis_kb_config.env
+++ b/jarvis_kb_config.env
@@ -33,18 +33,6 @@ SESSION_CONTEXT_DIR=/tmp/jarvis_sessions
 # Vector dimension for embeddings
 EMBEDDING_DIM=768
 
-# Enable auto-discovery of knowledge bases
-ENABLE_KB_DISCOVERY=true
-
-# Enable multi-KB search
-ENABLE_MULTI_KB_SEARCH=true
-
-# Max number of results per KB
-MAX_RESULTS_PER_KB=5
-
-# Max total results across all KBs
-MAX_TOTAL_RESULTS=10
-
 # Document processing parameters
 DOCUMENT_CHUNK_SIZE=1536
 DOCUMENT_CHUNK_OVERLAP=256


### PR DESCRIPTION
## Summary
- remove unused knowledge base search settings from `jarvis_kb_config.env`
- update README to no longer advertise those unused variables

## Testing
- `python -m py_compile document_processor.py hybrid_search/hybrid_search.py`

## Summary by Sourcery

Remove unused knowledge base search environment variables and update documentation accordingly

Enhancements:
- Remove ENABLE_KB_DISCOVERY, ENABLE_MULTI_KB_SEARCH, and MAX_RESULTS_PER_KB from jarvis_kb_config.env

Documentation:
- Remove references to unused KB search settings from README.md