### PR TITLE
Fix embedding endpoint routing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       # Embedding Configuration
       - EMBEDDING_MODEL=nomic-embed-text
       - EMBEDDING_PROVIDER=ollama
-      - EMBEDDING_MODEL_ENDPOINT=http://ollama:11434
+      - EMBEDDING_MODEL_ENDPOINT=http://ollama-proxy:11435
       - EMBEDDING_DIMENSIONS=768
       - EMBEDDING_BATCH_SIZE=64
       # Performance optimizations

--- a/proxy/ollama_proxy.py
+++ b/proxy/ollama_proxy.py
@@ -44,6 +44,11 @@ except Exception as exc:
 def proxy(path):
     logger.info("Received request for /api/%s (Method: %s)", path, request.method)
 
+    # Map deprecated /embed endpoint to /embeddings for compatibility
+    if path == 'embed':
+        logger.debug("Redirecting /api/embed to /api/embeddings")
+        path = 'embeddings'
+
     data = request.get_json(silent=True)
 
     # For chat requests, augment with hybrid search context


### PR DESCRIPTION
## Summary
- map `/api/embed` to `/api/embeddings` in the proxy for compatibility
- route OpenWebUI embedding requests through the proxy

## Testing
- `pre-commit` *(fails: no configuration found)*