### PR TITLE
Remove unused OpenWebUI URL option

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,10 +324,6 @@ The main system configuration is in `docker-compose.yml` and `jarvis_kb_config.e
 *   `SPACY_MODEL`: spaCy language model to load (default: `en_core_web_lg`)
 *   `LOG_DIR`: Directory where the document processor writes logs (default: `./logs`)
 
-#### Proxy Settings
-
-* `OPENWEBUI_API_BASE_URL`: Base URL for the OpenWebUI API used by the hybrid search proxy (default: `http://open-webui:8080`)
-
 ### LLM Configuration
 
 The LLM is configured in the `Modelfile`. You can modify this file to change LLM parameters:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,6 @@ services:
       - NEO4J_PASSWORD=${NEO4J_PASSWORD}
       - NEO4J_URI=bolt://neo4j:7687
       - OLLAMA_API_BASE_URL=http://ollama:11434
-      - OPENWEBUI_API_BASE_URL=http://open-webui:8080
       - LOG_LEVEL=info
       - REQUEST_TIMEOUT=300
       - GRAPH_CACHE_SIZE=1000

--- a/hybrid_search/hybrid_search.py
+++ b/hybrid_search/hybrid_search.py
@@ -33,10 +33,10 @@ logging.basicConfig(
 logger = logging.getLogger("HybridSearch")
 
 class HybridSearch:
-    def __init__(self, neo4j_uri, neo4j_user, neo4j_password, milvus_host, milvus_port, ollama_url, openwebui_url=None):
+    def __init__(self, neo4j_uri, neo4j_user, neo4j_password, milvus_host, milvus_port, ollama_url):
+        """Initialise connections to Neo4j and Milvus."""
         # Neo4j connection with retries in case the database is not ready yet
         self.driver = None
-        self.openwebui_url = openwebui_url
         if GraphDatabase is not None:
             max_retries = int(os.environ.get("NEO4J_MAX_RETRIES", "10"))
             retry_delay = int(os.environ.get("NEO4J_RETRY_DELAY", "3"))

--- a/proxy/ollama_proxy.py
+++ b/proxy/ollama_proxy.py
@@ -24,7 +24,6 @@ if not NEO4J_PASSWORD:
 MILVUS_HOST = os.environ.get("MILVUS_HOST", "milvus-standalone")
 MILVUS_PORT = os.environ.get("MILVUS_PORT", "19530")
 OLLAMA_API_BASE_URL = os.environ.get("OLLAMA_API_BASE_URL", "http://ollama:11434")
-OPENWEBUI_API_BASE_URL = os.environ.get("OPENWEBUI_API_BASE_URL", "http://open-webui:8080")
 
 try:
     hybrid_search = HybridSearch(
@@ -34,7 +33,6 @@ try:
         milvus_host=MILVUS_HOST,
         milvus_port=MILVUS_PORT,
         ollama_url=OLLAMA_API_BASE_URL,
-        openwebui_url=OPENWEBUI_API_BASE_URL,
     )
 except Exception as exc:
     logger.error("Failed to initialise HybridSearch: %s", exc)


### PR DESCRIPTION
## Summary
- drop `openwebui_url` from `HybridSearch`
- update proxy to match
- remove unused environment variable from `docker-compose.yml` and docs

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

## Summary by Sourcery

Remove unused OpenWebUI URL configuration from HybridSearch and its proxy and clean up related environment variables and documentation

Enhancements:
- Drop the `openwebui_url` parameter and attribute from the HybridSearch constructor
- Remove `OPENWEBUI_API_BASE_URL` usage and injection in the proxy initialization

Documentation:
- Eliminate `OPENWEBUI_API_BASE_URL` entries from README documentation and docker-compose.yml