### PR TITLE
Remove unused session context config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -206,7 +206,6 @@ services:
       - open-webui-data:/app/backend/data
       - ./hybrid_search:/opt/jarvis/hybrid_search
       - ./logs:/var/log/jarvis
-      - ./tmp:/tmp/jarvis_sessions
       - ./config:/app/config
     env_file:
       - ./jarvis_kb_config.env

--- a/jarvis_kb_config.env
+++ b/jarvis_kb_config.env
@@ -28,8 +28,6 @@ CONFIG_DIR=/app/config
 # Logging directory
 LOG_DIR=/var/log/jarvis
 
-# Session context directory (for storing current KB context)
-SESSION_CONTEXT_DIR=/tmp/jarvis_sessions
 
 # Vector dimension for embeddings
 EMBEDDING_DIM=768


### PR DESCRIPTION
## Summary
- clean up `jarvis_kb_config.env` by removing `SESSION_CONTEXT_DIR`
- drop unused `/tmp/jarvis_sessions` volume from `docker-compose.yml`

## Testing
- `python -m py_compile document_processor.py hybrid_search/hybrid_search.py proxy/ollama_proxy.py`
- `pytest -q` *(fails: `pytest` not found)*

## Summary by Sourcery

Remove unused session context configuration and associated Docker volume mount.

Enhancements:
- Remove SESSION_CONTEXT_DIR from environment configuration.

Deployment:
- Drop unused /tmp/jarvis_sessions volume from docker-compose service.