### PR TITLE
Fix unused personal_concepts variable

### DIFF
--- a/document_processor.py
+++ b/document_processor.py
@@ -435,7 +435,6 @@ class DocumentProcessor:
         # Initialize results
         personal_entities = []
         personal_topics = []
-        personal_concepts = []
         personal_relationships = []
         
         # 1. PERSONAL IDENTIFIERS


### PR DESCRIPTION
## Summary
- remove unused `personal_concepts` variable from `extract_personal_knowledge`

## Testing
- `python -m py_compile document_processor.py`

## Summary by Sourcery

Bug Fixes:
- Remove unused `personal_concepts` variable from `extract_personal_knowledge`