### PR TITLE
Fix misleading chat route comment

### DIFF
--- a/hybrid_search/api.py
+++ b/hybrid_search/api.py
@@ -80,7 +80,7 @@ if FLASK_AVAILABLE:
             })
         except Exception as e:
             return jsonify({"status": "error", "error": str(e)}), 500
-# Chat endpoint stub (disabled due to missing proper indentation)
+# Chat endpoint stub (not yet implemented)
 if FLASK_AVAILABLE:
     @app.route('/chat', methods=['POST'])
     def chat():


### PR DESCRIPTION
## Summary
- update chat route comment to remove indentation reference

## Testing
- `python3 -m py_compile hybrid_search/api.py`
- `python3 -m compileall -q hybrid_search`

## Summary by Sourcery

Chores:
- Clarify the /chat route comment to state “not yet implemented” instead of referencing indentation