### PR TITLE
Fix import cleanup

### DIFF
--- a/document_processor.py
+++ b/document_processor.py
@@ -34,7 +34,6 @@ except ImportError:  # pragma: no cover - optional dependency
 import logging
 from datetime import datetime
 import sys
-import io
 import re
 import json
 import traceback


### PR DESCRIPTION
## Summary
- remove unused `io` import from document_processor

## Testing
- `python -m py_compile document_processor.py`
- `python -m compileall -q .`

## Summary by Sourcery

Chores:
- Remove unused `io` import from the document processor module.