### PR TITLE
Respect DEFAULT_KB_ID environment variable

### DIFF
--- a/document_processor.py
+++ b/document_processor.py
@@ -171,6 +171,16 @@ class DocumentProcessor:
         config_path = os.path.join(self.config_dir, "kb_default_config.json")
         
         try:
+            # Step 0: Check environment variable
+            env_kb = os.environ.get("DEFAULT_KB_ID")
+            if env_kb:
+                try:
+                    uuid.UUID(str(env_kb))
+                    logger.info(f"Using default KB ID from environment: {env_kb}")
+                    return env_kb
+                except Exception:
+                    logger.warning("Ignoring invalid DEFAULT_KB_ID environment variable")
+
             # Step 1: Try to read from persistent config file
             if os.path.exists(config_path):
                 with open(config_path, 'r') as f:

--- a/tests/test_default_kb.py
+++ b/tests/test_default_kb.py
@@ -1,0 +1,29 @@
+import os
+import json
+from document_processor import DocumentProcessor
+
+
+def test_env_default_kb_precedence(tmp_path, monkeypatch):
+    config_dir = tmp_path / "config"
+    processed_dir = tmp_path / "processed"
+    uploads_dir = tmp_path / "uploads"
+
+    config_dir.mkdir()
+    processed_dir.mkdir()
+    uploads_dir.mkdir()
+
+    # create config file with some other kb id
+    config_file = config_dir / "kb_default_config.json"
+    config_file.write_text(json.dumps({"default_kb_id": "00000000-0000-0000-0000-000000000000"}))
+
+    env_id = "11111111-1111-1111-1111-111111111111"
+
+    monkeypatch.setenv("CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("PROCESSED_DIR", str(processed_dir))
+    monkeypatch.setenv("UPLOADS_DIR", str(uploads_dir))
+    monkeypatch.setenv("NEO4J_PASSWORD", "dummy")
+    monkeypatch.setenv("DEFAULT_KB_ID", env_id)
+
+    dp = DocumentProcessor()
+
+    assert dp.default_kb_id == env_id


### PR DESCRIPTION
## Summary
- prioritize the `DEFAULT_KB_ID` environment variable when choosing the default KB ID
- add unit test verifying environment variable takes precedence over config file

## Testing
- `pytest --version` *(fails: command not found)*

## Summary by Sourcery

Use DEFAULT_KB_ID environment variable for the default KB ID with validation and fallback to config, and add a test for this behavior.

New Features:
- Prioritize the DEFAULT_KB_ID environment variable as the default KB ID when valid

Tests:
- Add unit test to verify that the environment variable takes precedence over the config file