### PR TITLE
Validate embedding dimension before Milvus insert

### DIFF
--- a/document_processor.py
+++ b/document_processor.py
@@ -967,6 +967,14 @@ class DocumentProcessor:
         try:
             collection_name = f"documents_{kb_id.replace('-', '_')}"
 
+            # Validate embedding dimension before insertion
+            expected_dim = getattr(self.searcher, "embedding_dim", None)
+            if expected_dim is not None and len(embedding) != expected_dim:
+                logger.warning(
+                    f"Embedding dimension mismatch: expected {expected_dim}, got {len(embedding)}; skipping insertion"
+                )
+                return
+
             # Create collection if it doesn't exist
             if not utility.has_collection(collection_name):
                 if not self.searcher._initialize_vector_collection(kb_id):

--- a/tests/test_document_processor.py
+++ b/tests/test_document_processor.py
@@ -1,0 +1,59 @@
+import os
+import types
+import unittest
+from unittest.mock import patch
+
+import document_processor
+
+class DummySearcher:
+    def __init__(self, *args, **kwargs):
+        self.embedding_dim = 3
+    def _initialize_vector_collection(self, kb_id):
+        return True
+
+class DummyCollection:
+    inserted_data = None
+    def __init__(self, name):
+        self.name = name
+    def load(self):
+        pass
+    def insert(self, data):
+        DummyCollection.inserted_data = data
+    def flush(self):
+        pass
+    def release(self):
+        pass
+
+def get_dummy_utility():
+    return types.SimpleNamespace(has_collection=lambda name: True)
+
+class AddVectorToMilvusTest(unittest.TestCase):
+    def setUp(self):
+        os.environ['NEO4J_PASSWORD'] = 'test'
+        self.patcher_searcher = patch('document_processor.HybridSearch', DummySearcher)
+        self.patcher_collection = patch('document_processor.Collection', DummyCollection)
+        self.patcher_utility = patch('document_processor.utility', get_dummy_utility())
+        self.patcher_searcher.start()
+        self.patcher_collection.start()
+        self.patcher_utility.start()
+
+    def tearDown(self):
+        self.patcher_searcher.stop()
+        self.patcher_collection.stop()
+        self.patcher_utility.stop()
+        DummyCollection.inserted_data = None
+
+    def test_embedding_mismatch_skips_insert(self):
+        dp = document_processor.DocumentProcessor()
+        with self.assertLogs('DocumentProcessor', level='WARNING') as cm:
+            dp.add_vector_to_milvus('t', 'p', 'c', 'kb', [1, 2])
+        self.assertIsNone(DummyCollection.inserted_data)
+        self.assertTrue(any('Embedding dimension mismatch' in m for m in cm.output))
+
+    def test_embedding_match_inserts(self):
+        dp = document_processor.DocumentProcessor()
+        dp.add_vector_to_milvus('t', 'p', 'c', 'kb', [1, 2, 3])
+        self.assertIsNotNone(DummyCollection.inserted_data)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- warn and skip if embedding size doesn't match expected dimension
- add basic unit tests for Milvus insertion logic

## Testing
- `python -m unittest discover -s tests`

## Summary by Sourcery

Validate embedding dimensions against the expected size before inserting vectors into Milvus, skipping mismatched embeddings with a warning, and add unit tests to cover both mismatch and successful insertion scenarios.

New Features:
- Skip Milvus insertion and log a warning when embedding dimension does not match the expected size.

Tests:
- Add unit tests validating that mismatched embeddings are skipped and correctly log a warning provided embedding dimensions match the expected size and insert as expected.