### PR TITLE
Allow uppercase UUIDs in knowledge base paths

### DIFF
--- a/document_processor.py
+++ b/document_processor.py
@@ -776,7 +776,7 @@ class DocumentProcessor:
                 if len(path_parts) > uploads_index + 1:
                     kb_id = path_parts[uploads_index + 1]
                     # Validate that it looks like a UUID (simple check)
-                    if re.match(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', kb_id):
+                    if re.match(r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$', kb_id):
                         logger.info(f"Extracted KB ID from path: {kb_id}")
                         return kb_id
             
@@ -1117,7 +1117,7 @@ class DocumentProcessor:
                     item_path = os.path.join(self.uploads_dir, item)
                     if os.path.isdir(item_path):
                         # Check if the directory name looks like a UUID (KB ID)
-                        if re.match(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', item):
+                        if re.match(r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$', item):
                             kb_ids.add(item)
                         
                         # Also check for .kb_config files

--- a/tests/test_document_processor.py
+++ b/tests/test_document_processor.py
@@ -1,0 +1,36 @@
+import os
+import tempfile
+import unittest
+
+from document_processor import DocumentProcessor
+
+class TestExtractKbId(unittest.TestCase):
+    def setUp(self):
+        # Use temporary directories for environment paths
+        self.temp_dir = tempfile.TemporaryDirectory()
+        os.environ['UPLOADS_DIR'] = os.path.join(self.temp_dir.name, 'uploads')
+        os.environ['PROCESSED_DIR'] = os.path.join(self.temp_dir.name, 'processed')
+        os.environ['CONFIG_DIR'] = os.path.join(self.temp_dir.name, 'config')
+        os.makedirs(os.environ['UPLOADS_DIR'], exist_ok=True)
+        os.makedirs(os.environ['PROCESSED_DIR'], exist_ok=True)
+        os.makedirs(os.environ['CONFIG_DIR'], exist_ok=True)
+        os.environ['NEO4J_PASSWORD'] = 'dummy'
+        self.processor = DocumentProcessor()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_lowercase_uuid(self):
+        uuid_lower = '123e4567-e89b-12d3-a456-426614174000'
+        path = os.path.join('some', 'path', 'uploads', uuid_lower, 'file.txt')
+        kb_id = self.processor.extract_kb_id_from_path(path)
+        self.assertEqual(kb_id, uuid_lower)
+
+    def test_uppercase_uuid(self):
+        uuid_upper = '123E4567-E89B-12D3-A456-426614174000'
+        path = os.path.join('another', 'path', 'uploads', uuid_upper, 'file.txt')
+        kb_id = self.processor.extract_kb_id_from_path(path)
+        self.assertEqual(kb_id, uuid_upper)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- accept KB IDs containing uppercase hex characters
- add tests for lowercase and uppercase UUID paths

## Testing
- `python -m unittest discover -v`