### PR TITLE
Add unit tests and pytest config

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -ra

--- a/tests/test_chunk_text.py
+++ b/tests/test_chunk_text.py
@@ -1,0 +1,34 @@
+import pytest
+
+from document_processor import DocumentProcessor
+
+
+def make_processor(chunk_size, chunk_overlap):
+    proc = DocumentProcessor.__new__(DocumentProcessor)
+    proc.chunk_size = chunk_size
+    proc.chunk_overlap = chunk_overlap
+    return proc
+
+
+def test_chunk_text_basic():
+    proc = make_processor(chunk_size=10, chunk_overlap=2)
+    text = "abcdefghijklmnopqrstuvwxyz"
+    chunks = proc.chunk_text(text)
+    assert chunks == [
+        "abcdefghij",
+        "ijklmnopqr",
+        "qrstuvwxyz",
+        "yz",
+    ]
+
+
+def test_chunk_text_non_positive_size():
+    proc = make_processor(chunk_size=0, chunk_overlap=0)
+    assert proc.chunk_text("hello") == ["hello"]
+
+
+def test_chunk_text_step_adjustment():
+    proc = make_processor(chunk_size=5, chunk_overlap=10)
+    # overlap >= size -> step becomes size (5)
+    text = "abcdefghij"
+    assert proc.chunk_text(text) == ["abcde", "fghij"]

--- a/tests/test_extract_kb_id.py
+++ b/tests/test_extract_kb_id.py
@@ -1,0 +1,55 @@
+import json
+from pathlib import Path
+
+from document_processor import DocumentProcessor
+
+
+class DummySearcher:
+    def __init__(self, kb_ids):
+        self._kb_ids = kb_ids
+
+    def get_available_knowledge_bases(self):
+        return self._kb_ids
+
+
+def make_processor(searcher=None, default="default-id"):
+    proc = DocumentProcessor.__new__(DocumentProcessor)
+    proc.default_kb_id = default
+    proc.searcher = searcher
+    return proc
+
+
+def test_extract_kb_id_from_upload_path(tmp_path):
+    kb_id = "123e4567-e89b-12d3-a456-426614174000"
+    path = tmp_path / "uploads" / kb_id / "file.txt"
+    path.parent.mkdir(parents=True)
+    path.write_text("data")
+    proc = make_processor()
+    assert proc.extract_kb_id_from_path(str(path)) == kb_id
+
+
+def test_extract_kb_id_from_config(tmp_path):
+    kb_id = "abcdefab-1234-5678-abcd-1234567890ab"
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("data")
+    config = tmp_path / ".kb_config"
+    config.write_text(json.dumps({"kb_id": kb_id}))
+    proc = make_processor()
+    assert proc.extract_kb_id_from_path(str(file_path)) == kb_id
+
+
+def test_extract_kb_id_from_searcher(tmp_path):
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("data")
+    searcher = DummySearcher(["deadbeef-dead-beef-dead-beefdeadbeef"])
+    proc = make_processor(searcher=searcher, default="fallback")
+    assert proc.extract_kb_id_from_path(str(file_path)) == searcher._kb_ids[0]
+
+
+def test_extract_kb_id_default(tmp_path):
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("data")
+    searcher = DummySearcher([])
+    proc = make_processor(searcher=searcher, default="fallback")
+    assert proc.extract_kb_id_from_path(str(file_path)) == "fallback"
+

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -1,0 +1,21 @@
+from hybrid_search.hybrid_search import HybridSearch
+
+
+def make_searcher():
+    return HybridSearch.__new__(HybridSearch)
+
+
+def test_extract_query_terms_basic():
+    searcher = make_searcher()
+    query = "How to use Python for data processing?"
+    terms = searcher._extract_query_terms(query)
+    assert terms == ["Use", "Python", "Data", "Processing"]
+
+
+def test_extract_query_terms_filters_stopwords():
+    searcher = make_searcher()
+    query = "What can you tell me about AI and ML?"
+    terms = searcher._extract_query_terms(query)
+    assert "What" not in terms and "You" not in terms
+    assert "Ai" in terms and "Ml" in terms
+


### PR DESCRIPTION
## Summary
- add a `tests/` package with basic unit tests
- cover `chunk_text`, `extract_kb_id_from_path`, and `HybridSearch._extract_query_terms`
- include minimal `pytest.ini`

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*