### PR TITLE
Add context length configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,9 @@ The main system configuration is in `docker-compose.yml` and `jarvis_kb_config.e
 * `OLLAMA_URL` – base URL used by the document processor for generating embeddings
 *   `OLLAMA_NUM_PARALLEL`: Number of parallel requests allowed (default: 4)
 *   `OLLAMA_MAX_LOADED_MODELS`: Maximum models to keep loaded (default: 2)
-*   `OLLAMA_CONTEXT_LENGTH`: Maximum context length (default: 262144)
+*   `OLLAMA_CONTEXT_LENGTH`: Context size passed to the embedding service. Set this
+    to a value supported by your model (default: 262144). For example, the
+    `nomic-embed-text` model works with `2048`.
 
 #### Vector Search Settings
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,10 @@ services:
       - OLLAMA_MODEL_PATH=/root/.ollama/models
       - OLLAMA_HOST=0.0.0.0
       - OLLAMA_NUM_THREADS=24
-      - OLLAMA_KEEP_ALIVE=10m  
+      - OLLAMA_KEEP_ALIVE=10m
       - OLLAMA_GPU_LAYERS=32    # This may work as an environment variable even if not as a model parameter
       - OLLAMA_PARALLEL=2       # This may work as an environment variable
+      - OLLAMA_CONTEXT_LENGTH=2048
       - CUDA_VISIBLE_DEVICES=0,1
     networks:
       - jarvis-net

--- a/hybrid_search/hybrid_search.py
+++ b/hybrid_search/hybrid_search.py
@@ -490,9 +490,24 @@ class HybridSearch:
             return None
 
         try:
+            ctx_env = os.environ.get("OLLAMA_CONTEXT_LENGTH", "2048")
+            try:
+                ctx = int(ctx_env)
+            except ValueError:
+                logger.warning(
+                    f"OLLAMA_CONTEXT_LENGTH '{ctx_env}' is not an integer; using default 2048"
+                )
+                ctx = 2048
+
+            payload = {
+                "model": self.model,
+                "prompt": text,
+                "options": {"num_ctx": ctx}
+            }
+
             response = requests.post(
                 f"{self.ollama_url}/api/embeddings",
-                json={"model": self.model, "prompt": text}
+                json=payload
             )
             
             if response.status_code == 200:


### PR DESCRIPTION
## Summary
- configure Ollama service with `OLLAMA_CONTEXT_LENGTH`
- pass embedding context length in HybridSearch
- document new variable in README

## Testing
- `python -m py_compile hybrid_search/hybrid_search.py`
- `pip install pytest` *(fails: Could not find a version that satisfies the requirement)*