### PR TITLE
Prevent long prompts from exceeding embedding context

### DIFF
--- a/hybrid_search/hybrid_search.py
+++ b/hybrid_search/hybrid_search.py
@@ -499,10 +499,19 @@ class HybridSearch:
                 )
                 ctx = 2048
 
+            # Truncate long prompts to avoid server errors when context is exceeded
+            max_chars = ctx * 4  # Rough approximation of token to char ratio
+            if len(text) > max_chars:
+                logger.warning(
+                    "Prompt too long for configured context; truncating to %d characters",
+                    max_chars,
+                )
+                text = text[:max_chars]
+
             payload = {
                 "model": self.model,
                 "prompt": text,
-                "options": {"num_ctx": ctx}
+                "options": {"num_ctx": ctx},
             }
 
             response = requests.post(


### PR DESCRIPTION
## Summary
- trim prompts in `_get_embedding` if they exceed configured context length

## Testing
- `PYTHONPATH=. python tests/test_document_processor.py` *(fails: spaCy/neo4j etc not installed but tests run)*

## Summary by Sourcery

Truncate long prompts in the `_get_embedding` method based on the configured context length (using a rough token-to-character approximation) to avoid exceeding the embedding model's context and causing server errors.

Bug Fixes:
- Prevent server errors by truncating input text in `_get_embedding` when it exceeds the model's context length

Enhancements:
- Log a warning upon truncating overly long prompts to inform users